### PR TITLE
Implement quote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
   - "3.4"
 install:
   # Build/test dependencies
-  - pip install -r requirements.txt  
+  - pip install -r requirements.txt
 script:
   # Linting
-  - flake8 tululbot.py
+  - flake8 *.py
   # Run tests
   - py.test

--- a/QuoteEngine.py
+++ b/QuoteEngine.py
@@ -1,0 +1,28 @@
+import random
+
+import requests
+import yaml
+
+
+class QuoteEngine:
+
+    def __init__(self):
+        self.quote_url = 'https://cdn.rawgit.com/tulul/tulul-quotes/master/quote.yaml'  # noqa
+        # Note: rawgit does not have 100% uptime, but at
+        # least they're not throttling us.
+
+        self.cache = []
+
+    def retrieve_random(self):
+        cache = self.cache
+        return self.format_quote(random.choice(cache))
+
+    def format_quote(self, q):
+        return '{q[quote]} - {q[author]}, {q[author_bio]}'.format(q=q)
+
+    def refresh_cache(self):
+        body = requests.get(self.quote_url).text
+        # What if previosuly we have the cache, but this time
+        # when we try to get new cache, the network occurs error?
+        # We will think about "don't refresh if error" later.
+        self.cache = yaml.load(body)['quotes']

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pep8==1.5.7
 py==1.4.30
 pyflakes==0.8.1
 pytest==2.8.0
+PyYaml==3.11
 requests==2.7.0
 Werkzeug==0.10.4
 wheel==0.24.0

--- a/test_tululbot.py
+++ b/test_tululbot.py
@@ -215,6 +215,31 @@ def test_leli_command_with_multiword_term(app):
         )
 
 
+def test_quote(app):
+    payload = {
+        'update_id': 12345,
+        'message': {
+            'message_id': 100,
+            'text': '/quote',
+            'chat': {
+                'id': 1
+            }
+        }
+    }
+
+    rv = app.post('/', data=json.dumps(payload),
+                  content_type='application/json')
+
+    assert rv.status_code == 200
+    json_response = json.loads(rv.get_data(as_text=True))
+    assert json_response['method'] == 'sendMessage'
+    assert json_response['chat_id'] == 1
+    # Fix the test later, baby
+    # assert json_response['text'] == expected_text
+    assert json_response['disable_web_page_preview'] == 'false'
+    assert json_response['reply_to_message_id'] == 100
+
+
 def test_who_command(app):
     payload = {
         'update_id': 12345,

--- a/tululbot.py
+++ b/tululbot.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 from flask import Flask, request, jsonify
 from bs4 import BeautifulSoup
 import requests
+from QuoteEngine import QuoteEngine
 
 
 def create_app(config_dict):
@@ -18,6 +19,9 @@ def create_app(config_dict):
 
     # Configure application logging
     app.logger.setLevel(app.config['LOG_LEVEL'])
+
+    quote_engine = QuoteEngine()
+    quote_engine.refresh_cache()
 
     def leli(term):
         """
@@ -103,6 +107,8 @@ def create_app(config_dict):
                     if not term:
                         return reply('Apa yang mau dileli?')
                     return reply(leli(term))
+                elif text.startswith('/quote'):
+                    return reply(quote_engine.retrieve_random())
                 elif text == '/who':
                     about_text = (
                         'TululBot v0.1.0\n\n'


### PR DESCRIPTION
Implement basic quote. However, this thing needs more improvement:

- Live reload every five minutes. It is inconvenient to restart the web just to reload new quote entry
- How to test? The test only check the status -- not checking whether. Perhaps i should use `quote_exist` but i don't think it is trivial.
- The test is now slower because it loads from git each time a case run. Need to inject QuoteEngine to upper layer (so it does not need to be instantiated per test case)