### PR TITLE
Search slang word to urbandictionary.com first

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ requests==2.7.0
 simplegeneric==0.8.1
 six==1.10.0
 traitlets==4.0.0
+urbandict==0.5
 Werkzeug==0.10.4
-wheel==0.24.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -127,7 +127,7 @@ def test_who(fake_message, mocker):
     who(fake_message)
 
     expected_text = (
-        'TululBot v1.1.1\n\n'
+        'TululBot v1.2.1\n\n'
         'Enhancing your tulul experience since 2015\n\n'
         'Contribute on https://github.com/tulul/tululbot\n\n'
         "We're hiring! Contact @iqbalmineraltown for details"

--- a/tululbot/commands.py
+++ b/tululbot/commands.py
@@ -37,7 +37,7 @@ def quote(message):
 def who(message):
     app.logger.debug('Detected as who command')
     about_text = (
-        'TululBot v1.1.1\n\n'
+        'TululBot v1.2.1\n\n'
         'Enhancing your tulul experience since 2015\n\n'
         'Contribute on https://github.com/tulul/tululbot\n\n'
         "We're hiring! Contact @iqbalmineraltown for details"


### PR DESCRIPTION
This PR makes `/slang` command fetch definition from urbandictionary.com first. If not found then it will fetch from kamusslang.com.